### PR TITLE
Directive for dynamic <title>

### DIFF
--- a/src/app/layout/layout.directives.js
+++ b/src/app/layout/layout.directives.js
@@ -26,14 +26,13 @@ angular.module('layout').directive('sqidApp', [function() {
 	function link(scope, element, attrs) {
 
 		$rootScope.$on('$routeChangeStart', function(e, next, current) {
-			var page, 
-				custom = '',
+			var page,
 				suffix = ' - SQID';
 
 			switch(next.$$route.originalPath.substr(1)) {
 				case '': page = 'PAGE_TITLE.START'; break;
 				case 'about': page = 'NAV.ABOUT'; break;
-				case 'browse':browseTitle(); break;
+				case 'browse': browseTitle(); break;
 				case 'view' : viewTitle(); break;
 				case 'query': page = 'PAGE_TITLE.QUERY'; break;
 				default: page = false;
@@ -58,7 +57,7 @@ angular.module('layout').directive('sqidApp', [function() {
 				page = 'PAGE_TITLE.VIEW';
 				if(next.params.id) {
 					i18n.waitForTerms([next.params.id]).then(function() {
-						custom = ': ' + i18n.getEntityLabel(next.params.id);
+						page = i18n.getEntityLabel(next.params.id);
 						updateElement();
 					});
 				}
@@ -66,8 +65,8 @@ angular.module('layout').directive('sqidApp', [function() {
 
 			function updateElement() {
 				var text = 'SQID - Wikidata Explorer';
-				if(page) {
-					text = page + custom + suffix;
+				if (page) {
+					text = page + suffix;
 				}
 				element.text(text);
 			}

--- a/src/app/layout/layout.directives.js
+++ b/src/app/layout/layout.directives.js
@@ -1,13 +1,15 @@
 //////// Module Definition ////////////
 define([
 	'layout/layout.module',
+	'i18n/i18n.config',
 	'meta/statistics.service'
 ], function() {
 ///////////////////////////////////////
 
 angular.module('layout').directive('sqidApp', [function() {
 	return {
-		templateUrl: 'app/layout/layout.html'
+		templateUrl: 'app/layout/layout.html',
+		restrict: 'A'
 	};
 }]).directive('sqidMainNav', [function() {
 	return {
@@ -15,6 +17,58 @@ angular.module('layout').directive('sqidApp', [function() {
 	};
 }])
 
+.directive('sqidTitle', ['$rootScope', 'i18n', '$translate', function($rootScope, i18n, $translate) {
+
+	return {
+		link: link,
+		restrict: 'A'
+	};
+	function link(scope, element, attrs) {
+
+		$rootScope.$on('$routeChangeStart', function(e, next, current) {
+			var page, 
+				custom = '',
+				suffix = ' - SQID';
+
+			switch(next.$$route.originalPath.substr(1)) {
+				case '': page = 'PAGE_TITLE.START'; break;
+				case 'about': page = 'NAV.ABOUT'; break;
+				case 'browse':browseTitle(); break;
+				case 'view' : viewTitle(); break;
+				case 'query': page = 'PAGE_TITLE.QUERY'; break;
+				default: page = false;
+			}
+			if(page) { 
+				$translate(page).then(function(str) {
+					page = str;
+					updateElement();
+				});
+			}
+
+			function browseTitle() {
+				page = (next.params.type === 'properties' ? 'PAGE_TITLE.PROPERTIES' : 'PAGE_TITLE.CLASSES');
+			}
+
+			function viewTitle() {
+				page = 'PAGE_TITLE.VIEW';
+				if(next.params.id) {
+					i18n.waitForTerms([next.params.id]).then(function() {
+						custom = ': ' + i18n.getEntityLabel(next.params.id);
+						updateElement();
+					});
+				}
+			}
+
+			function updateElement() {
+				var text = 'SQID - Wikidata Explorer';
+				if(page) {
+					text = page + custom + suffix;
+				}
+				element.text(text);
+			}
+		});
+	}
+}])
 
 .directive('sqidImage', ['wikidataapi', function(wikidataapi) {
 

--- a/src/app/layout/layout.directives.js
+++ b/src/app/layout/layout.directives.js
@@ -38,11 +38,16 @@ angular.module('layout').directive('sqidApp', [function() {
 				case 'query': page = 'PAGE_TITLE.QUERY'; break;
 				default: page = false;
 			}
-			if(page) { 
-				$translate(page).then(function(str) {
-					page = str;
-					updateElement();
-				});
+			if(page) {
+				(function translatePageName() {
+					if(!$translate.isReady()) { setTimeout(translatePageName,100); }
+					else {
+						$translate(page).then(function(str) {
+							page = str;
+							updateElement();
+						});
+					}
+				})();
 			}
 
 			function browseTitle() {

--- a/src/app/layout/layout.directives.js
+++ b/src/app/layout/layout.directives.js
@@ -30,12 +30,12 @@ angular.module('layout').directive('sqidApp', [function() {
 				suffix = ' - SQID';
 
 			switch(next.$$route.originalPath.substr(1)) {
-				case '': page = 'PAGE_TITLE.START'; break;
-				case 'about': page = 'NAV.ABOUT'; break;
+				case '':       page = 'PAGE_TITLE.START'; break;
+				case 'about':  page = 'PAGE_TITLE.ABOUT'; break;
 				case 'browse': browseTitle(); break;
-				case 'view' : viewTitle(); break;
-				case 'query': page = 'PAGE_TITLE.QUERY'; break;
-				default: page = false;
+				case 'view' :  viewTitle(); break;
+				case 'query':  page = 'PAGE_TITLE.QUERY'; break;
+				default:       page = false;
 			}
 			if(page) {
 				(function translatePageName() {
@@ -54,7 +54,7 @@ angular.module('layout').directive('sqidApp', [function() {
 			}
 
 			function viewTitle() {
-				page = 'PAGE_TITLE.VIEW';
+				page = false;
 				if(next.params.id) {
 					i18n.waitForTerms([next.params.id]).then(function() {
 						page = i18n.getEntityLabel(next.params.id);

--- a/src/app/layout/layout.module.js
+++ b/src/app/layout/layout.module.js
@@ -5,6 +5,8 @@ define([
 	'ngRoute',
 	'jquery-ui',
 	'ui-boostrap-tpls',
+	'i18n/i18n.module',
+	'util/util.module',
 	'meta/meta.module',
 	'entitySearch/entitySearch.module'
 ], function() {
@@ -12,7 +14,7 @@ define([
 
 angular.module('layout', [
 	'ngAnimate', 'ngRoute', 'ui.bootstrap', 'pascalprecht.translate',
-	'meta'
+	'i18n',	'util', 'entitySearch', 'meta'
 ]);
 
 return {}; }); // module definition end

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf8" />
-  <title>SQID - Wikidata Explorer</title>
+  <title sqid-title>SQID - Wikidata Explorer</title>
   <link rel="stylesheet" href="lib/bootstrap-3.3.6-dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="style.css">
@@ -14,5 +14,5 @@
   <!--<script data-main="app/dist.min" src="lib/require.js"></script> <!-- production -->
 
 </head>
-<body sqid-app></body>
+<body><div data-sqid-app></body>
 </html>

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -1,10 +1,18 @@
 
 {
-	"NAV": {
-		"PROPERTIES": "Eigenschaften",
+	"PAGE_TITLE": {
 		"CLASSES": "Klassen",
+		"PROPERTIES": "Eigenschaften",
 		"START": "Start",
 		"ABOUT": "Über SQID",
+		"VIEW" : "Browser",
+		"QUERY": "Suche"
+	},
+	"NAV": {
+		"PROPERTIES": "@:PAGE_TITLE.PROPERTIES",
+		"CLASSES": "@:PAGE_TITLE.CLASSES",
+		"START": "@:PAGE_TITLE.START",
+		"ABOUT": "@:PAGE_TITLE.ABOUT",
 		"ITEM_SEARCH": "Suche nach Item"
 	},
 	"FOOTER": {

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -5,7 +5,6 @@
 		"PROPERTIES": "Eigenschaften",
 		"START": "Start",
 		"ABOUT": "Über SQID",
-		"VIEW" : "Browser",
 		"QUERY": "Suche"
 	},
 	"NAV": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1,9 +1,17 @@
 {
+	"PAGE_TITLE": {
+		"CLASSES": "Classes Browser",
+		"PROPERTIES": "Properties Browser",
+		"START": "Start",
+		"ABOUT": "About",
+		"VIEW" : "View",
+		"QUERY": "Query Interface"
+	},
 	"NAV": {
 		"PROPERTIES": "Properties",
 		"CLASSES": "Classes",
 		"START": "Start",
-		"ABOUT": "About",
+		"ABOUT": "@:PAGE_TITLE.ABOUT",
 		"ITEM_SEARCH": "Search Item"
 	},
 	"FOOTER": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -4,7 +4,6 @@
 		"PROPERTIES": "Properties",
 		"START": "Start",
 		"ABOUT": "About",
-		"VIEW" : "View",
 		"QUERY": "Query"
 	},
 	"NAV": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1,16 +1,16 @@
 {
 	"PAGE_TITLE": {
-		"CLASSES": "Classes Browser",
-		"PROPERTIES": "Properties Browser",
+		"CLASSES": "Classes",
+		"PROPERTIES": "Properties",
 		"START": "Start",
 		"ABOUT": "About",
 		"VIEW" : "View",
-		"QUERY": "Query Interface"
+		"QUERY": "Query"
 	},
 	"NAV": {
-		"PROPERTIES": "Properties",
-		"CLASSES": "Classes",
-		"START": "Start",
+		"PROPERTIES": "@:PAGE_TITLE.PROPERTIES",
+		"CLASSES": "@:PAGE_TITLE.CLASSES",
+		"START": "@:PAGE_TITLE.START",
 		"ABOUT": "@:PAGE_TITLE.ABOUT",
 		"ITEM_SEARCH": "Search Item"
 	},


### PR DESCRIPTION
This addresses #84

An attribute directive for the `<title>` element that listens to `$routeChangeStart` on `$rootScope` and generates a new title every time.

This approach actually takes away from the modularity since declaring titles for pages is something that should be handled by the module that contains those pages. Then again it's an edge case and having it in one place is also convenient.

The `<body>` element's sqid-app directive had to be moved one level down in a wrapping div, otherwise there was a special race condition when refreshing a page with remotely retrieved labels in title:
1. squidTitle directive makes an wikidataapi ajax call, so angular appends a `<script>` node to the body 
2. squidApp directive replaces contents of `<body>`
3. when the callback for the request fires, angular tries to remove the `<script>` node that is no longer there, causing a JS error.
(that was a mean one to figure out...)
