### PR TITLE
Make dataUpdate py2/py3 compatible (and a bit more intuitive to use)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ src/data/classes.json
 src/data/properties.json
 src/data/statistics.json
 node_modules
+*.pyc
+\#*\#
+*~
+.\#*

--- a/helpers/python/dataUpdate.py
+++ b/helpers/python/dataUpdate.py
@@ -208,3 +208,14 @@ def updatePropertyRecords() :
 	print("Property update complete.")
 
 #pprint.pprint(propertyStatistics)
+
+if __name__ == '__main__':
+	# ensure we are in the correct directory
+	wd = os.getcwd()
+	try:
+		os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+				      '..', '..', 'src', 'data'))
+		updateClassRecords()
+		updatePropertyRecords()
+	finally:
+		os.chdir(wd)


### PR DESCRIPTION
Use print_function to stay compatible with Python 3.  Handle non-existing data files gracefully.  Try to be clever if someone runs `python helpers/python/dataUpdate.py` and chdir to the correct directory.